### PR TITLE
feat(#23): 업비트 API with d3.js 거래소 구현

### DIFF
--- a/components/chart/Candle.tsx
+++ b/components/chart/Candle.tsx
@@ -1,0 +1,87 @@
+import type { CandleByTickerProps, Change } from '@interface/market'
+import React, { useEffect } from 'react'
+import * as d3 from 'd3'
+
+interface Props extends Pick<CandleByTickerProps, 'opening_price' | 'high_price' | 'low_price' | 'trade_price'> {
+ refEl: React.RefObject<SVGSVGElement>
+ yesterdayChnage: Change
+}
+
+function Candle(props: Props) {
+ const { high_price, low_price, opening_price, refEl, trade_price, yesterdayChnage } = props
+
+ useEffect(() => {
+  if (!refEl?.current) return
+
+  const { width, height } = refEl.current.getClientRects()[0]
+
+  const low = opening_price - low_price
+  const high = high_price - opening_price
+
+  const max = Math.max(low, high)
+
+  const yScale = d3
+   .scaleLinear()
+   .domain([opening_price - max, opening_price + max])
+   .range([height, 0])
+
+  d3
+   .select(refEl.current)
+   .call((g) => g.selectAll('rect').remove())
+   .append('rect')
+   .attr('width', width)
+   .attr('height', () => {
+    const result = Math.abs(yScale(opening_price) - yScale(trade_price))
+    return result === 0 ? 1 : result
+   })
+   .attr('x', 0)
+   .attr('y', () => yScale(Math.max(trade_price, opening_price)))
+   .attr('fill', () => {
+    if (yesterdayChnage === 'RISE') return '#c84a31'
+    else if (yesterdayChnage === 'FALL') return '#1261c4'
+    const result = opening_price > trade_price
+
+    return result ? '#1261c4' : 'black'
+   })
+
+  const doc2 = d3.select(refEl.current)
+
+  const up = trade_price > opening_price
+
+  doc2
+   .call((g) => g.selectAll('.high-line').remove())
+   .append('line')
+   .attr('class', 'high-line')
+   .attr('x1', width / 2)
+   .attr('x2', width / 2)
+   .attr('y1', up ? yScale(trade_price) : yScale(opening_price))
+   .attr('y2', yScale(high_price))
+   .attr('stroke', () => {
+    if (yesterdayChnage === 'RISE') return '#c84a31'
+    else if (yesterdayChnage === 'FALL') return '#1261c4'
+    const result = opening_price > trade_price
+
+    return result ? '#1261c4' : 'black'
+   })
+
+  doc2
+   .call((g) => g.selectAll('.low-line').remove())
+   .append('line')
+   .attr('class', 'low-line')
+   .attr('x1', width / 2)
+   .attr('x2', width / 2)
+   .attr('y1', yScale(Math.max(trade_price, opening_price)))
+   .attr('y2', yScale(low_price))
+   .attr('stroke', () => {
+    if (yesterdayChnage === 'RISE') return '#c84a31'
+    else if (yesterdayChnage === 'FALL') return '#1261c4'
+    const result = opening_price > trade_price
+
+    return result ? '#1261c4' : 'black'
+   })
+ }, [high_price, low_price, opening_price, refEl, trade_price, yesterdayChnage])
+
+ return <></>
+}
+
+export default Candle

--- a/components/common/NavLink.tsx
+++ b/components/common/NavLink.tsx
@@ -21,8 +21,6 @@ function NavLink(props: Props) {
   setActive(activePathname === linkPathname)
  }, [asPath, props])
 
- console.log(active)
-
  return (
   <Link {...rest} passHref>
    <LinkBlock active={active} className={active ? 'active' : ''}>

--- a/components/market/grid/Grid.tsx
+++ b/components/market/grid/Grid.tsx
@@ -1,0 +1,30 @@
+import { useAppSelector } from '@features/hooks'
+import type { CandleByTickerProps } from '@interface/market'
+import React from 'react'
+import Row from './Row'
+import * as _ from 'lodash'
+
+interface Props {
+ data: CandleByTickerProps[]
+}
+
+function Grid(props: Props) {
+ const { data } = props
+ const { markets } = useAppSelector((state) => state.market)
+
+ return (
+  <div>
+   <div style={{ maxHeight: '320px', overflow: 'auto' }}>
+    {data.map((market) => (
+     <Row
+      key={market.market}
+      data={market}
+      koreanName={_.find(markets, { market: market.market })?.korean_name ?? ''}
+     />
+    ))}
+   </div>
+  </div>
+ )
+}
+
+export default React.memo(Grid)

--- a/components/market/grid/Row.tsx
+++ b/components/market/grid/Row.tsx
@@ -1,0 +1,74 @@
+import Mark from '@components/market/grid/column/Mark'
+import Percent from '@components/market/grid/column/Percent'
+import Price from '@components/market/grid/column/Price'
+import Symbol from '@components/market/grid/column/Symbol'
+import TodayCandle from '@components/market/grid/column/TodayCandle'
+import Volume from '@components/market/grid/column/Volume'
+import usePrevious from '@hooks/usePrevious'
+import type { CandleByTickerProps } from '@interface/market'
+import { numberToHuman } from '@utils/markets'
+import React, { useMemo } from 'react'
+import styled from 'styled-components'
+
+interface Props {
+ data: CandleByTickerProps
+ koreanName: string
+}
+
+function Row(props: Props) {
+ const { data, koreanName } = props
+
+ const previousChange = usePrevious(data.trade_price)
+
+ const enName = useMemo(() => {
+  const [krw, symbol] = data.market.split('-')
+
+  return `${symbol}/${krw}`
+ }, [data.market])
+
+ return (
+  <RowBlock>
+   <Mark />
+   <TodayCandle
+    opening_price={data.opening_price}
+    high_price={data.high_price}
+    low_price={data.low_price}
+    trade_price={data.trade_price}
+    yesterdayChnage={data.change}
+   />
+   <Symbol korName={koreanName} enName={enName} />
+   <Price
+    key={data.market}
+    tradePrice={data.trade_price.toLocaleString()}
+    yesterdayChnage={data.change}
+    change={
+     data.trade_price > (previousChange ?? 0) ? 'RISE' : data.trade_price < (previousChange ?? 0) ? 'FALL' : 'EVEN'
+    }
+   />
+   <Percent
+    signedChangeRate={`${data.signed_change_rate > 0 ? '+' : ''}${(data.signed_change_rate * 100).toFixed(2)}%`}
+    signedChangePrice={data.signed_change_price.toLocaleString()}
+    yesterdayChnage={data.change}
+   />
+   <Volume price={numberToHuman(data.acc_trade_price_24h)[0]} unit={numberToHuman(data.acc_trade_price_24h)[1]} />
+  </RowBlock>
+ )
+}
+
+const RowBlock = styled.div`
+ display: grid;
+ grid-template-columns: minmax(1rem, 7%) minmax(7px, 3%) 22.5% 22.5% 22.5% 22.5%;
+ padding: 10px;
+ border-bottom: 1px solid #d6d6d6;
+ transition: all 0.3s;
+ text-align: right;
+ color: #333;
+ font-size: 0.765rem;
+ cursor: default;
+
+ &:hover {
+  background-color: #efefef;
+ }
+`
+
+export default React.memo(Row)

--- a/components/market/grid/column/Mark.tsx
+++ b/components/market/grid/column/Mark.tsx
@@ -1,0 +1,12 @@
+import React from 'react'
+import StarIcon from '@mui/icons-material/Star'
+
+function Mark() {
+ return (
+  <div>
+   <StarIcon fontSize="small" color="disabled" />
+  </div>
+ )
+}
+
+export default React.memo(Mark)

--- a/components/market/grid/column/Percent.tsx
+++ b/components/market/grid/column/Percent.tsx
@@ -1,0 +1,50 @@
+import type { Change } from '@interface/market'
+import React from 'react'
+import styled, { css } from 'styled-components'
+
+interface Props {
+ signedChangeRate: string
+ signedChangePrice: string
+ yesterdayChnage: Change
+}
+
+function Percent(props: Props) {
+ const { signedChangeRate, signedChangePrice, yesterdayChnage } = props
+
+ return (
+  <PercentBlock yesterdayChnage={yesterdayChnage}>
+   <SignedChangeRateBlock>{signedChangeRate}</SignedChangeRateBlock>
+   <SignedChangePriceBlock>{signedChangePrice}</SignedChangePriceBlock>
+  </PercentBlock>
+ )
+}
+
+type PercentBlockProps = {
+ yesterdayChnage: 'RISE' | 'FALL' | 'EVEN'
+}
+
+const PercentBlock = styled.div<PercentBlockProps>`
+ transition: all 0.3s ease-in;
+ border: 1px solid rgba(0, 0, 0, 0);
+ font-weight: bold;
+ ${({ yesterdayChnage }) => {
+  if (yesterdayChnage === 'RISE') {
+   return css`
+    color: #c84a31;
+   `
+  } else if (yesterdayChnage === 'FALL') {
+   return css`
+    color: #1261c4;
+   `
+  } else {
+   return css`
+    color: #333;
+   `
+  }
+ }}
+`
+
+const SignedChangeRateBlock = styled.div``
+const SignedChangePriceBlock = styled.em``
+
+export default Percent

--- a/components/market/grid/column/Price.tsx
+++ b/components/market/grid/column/Price.tsx
@@ -1,0 +1,72 @@
+import usePrevious from '@hooks/usePrevious'
+import type { Change } from '@interface/market'
+import React, { useEffect, useState } from 'react'
+import styled, { css } from 'styled-components'
+
+interface Props {
+ tradePrice: string
+ change: Change
+ yesterdayChnage: Change
+}
+
+function Price(props: Props) {
+ const { tradePrice, change, yesterdayChnage } = props
+ const [currentChange, setCurrentChange] = useState<Change>(change)
+ const previousChange = usePrevious(change)
+
+ useEffect(() => {
+  if (previousChange !== change) {
+   setCurrentChange(change)
+  }
+  const id = setTimeout(() => {
+   setCurrentChange('EVEN')
+  }, 300)
+
+  return () => clearTimeout(id)
+ }, [change, previousChange])
+
+ return (
+  <ChageBlock change={currentChange} yesterdayChnage={yesterdayChnage}>
+   {tradePrice}
+  </ChageBlock>
+ )
+}
+
+type ChageBlockProps = {
+ change: 'RISE' | 'FALL' | 'EVEN'
+ yesterdayChnage: 'RISE' | 'FALL' | 'EVEN'
+}
+
+const ChageBlock = styled.div<ChageBlockProps>`
+ transition: all 0.3s ease-in;
+ border: 1px solid rgba(0, 0, 0, 0);
+ font-weight: bold;
+ ${({ change }) => {
+  if (change === 'RISE') {
+   return css`
+    border: 1px solid #c84a31;
+   `
+  } else if (change === 'FALL') {
+   return css`
+    border: 1px solid #1261c4;
+   `
+  }
+ }}
+ ${({ yesterdayChnage }) => {
+  if (yesterdayChnage === 'RISE') {
+   return css`
+    color: #c84a31;
+   `
+  } else if (yesterdayChnage === 'FALL') {
+   return css`
+    color: #1261c4;
+   `
+  } else {
+   return css`
+    color: #333;
+   `
+  }
+ }}
+`
+
+export default Price

--- a/components/market/grid/column/Symbol.tsx
+++ b/components/market/grid/column/Symbol.tsx
@@ -1,0 +1,32 @@
+import React from 'react'
+import styled from 'styled-components'
+
+interface Props {
+ korName: string
+ enName: string
+}
+
+function Symbol(props: Props) {
+ const { korName, enName } = props
+ return (
+  <SymbolBlock>
+   <TitleBlock>{korName}</TitleBlock>
+   <SubTitleBlock>{enName}</SubTitleBlock>
+  </SymbolBlock>
+ )
+}
+
+const SymbolBlock = styled.div`
+ text-align: left;
+`
+
+const TitleBlock = styled.div`
+ color: #333;
+ font-weight: 500;
+`
+
+const SubTitleBlock = styled.em`
+ color: #666;
+`
+
+export default React.memo(Symbol)

--- a/components/market/grid/column/TodayCandle.tsx
+++ b/components/market/grid/column/TodayCandle.tsx
@@ -1,0 +1,45 @@
+import Candle from '@components/chart/Candle'
+import type { CandleByTickerProps, Change } from '@interface/market'
+import React, { useEffect, useRef, useState } from 'react'
+import styled from 'styled-components'
+
+type Props = Pick<CandleByTickerProps, 'opening_price' | 'high_price' | 'low_price' | 'trade_price'> & {
+ yesterdayChnage: Change
+}
+
+function TodayCandle(props: Props) {
+ const { opening_price, high_price, low_price, trade_price, yesterdayChnage } = props
+ const divRef = useRef<HTMLDivElement>(null)
+ const svgRef = useRef<SVGSVGElement>(null)
+ const [height, setHeight] = useState<number>(0)
+
+ useEffect(() => {
+  if (divRef.current) {
+   const { height } = divRef.current.getClientRects()[0]
+   setHeight(height)
+  }
+ }, [])
+
+ return (
+  <TodayCandleBlock ref={divRef}>
+   <svg ref={svgRef} width={7} height={height}></svg>
+   {height && (
+    <Candle
+     refEl={svgRef}
+     high_price={high_price}
+     low_price={low_price}
+     opening_price={opening_price}
+     trade_price={trade_price}
+     yesterdayChnage={yesterdayChnage}
+    />
+   )}
+  </TodayCandleBlock>
+ )
+}
+
+const TodayCandleBlock = styled.div`
+ display: flex;
+ justify-content: center;
+`
+
+export default React.memo(TodayCandle)

--- a/components/market/grid/column/Volume.tsx
+++ b/components/market/grid/column/Volume.tsx
@@ -1,0 +1,29 @@
+import React from 'react'
+import styled from 'styled-components'
+
+interface Props {
+ price: string
+ unit: string
+}
+
+function Volume(props: Props) {
+ const { price, unit } = props
+ return (
+  <VolumeBlock>
+   <PriceBlock>{price}</PriceBlock>
+   <UnitBlock>{unit}</UnitBlock>
+  </VolumeBlock>
+ )
+}
+
+const VolumeBlock = styled.div`
+ display: flex;
+ justify-content: end;
+ letter-spacing: 1px;
+`
+const PriceBlock = styled.div``
+const UnitBlock = styled.div`
+ color: #999;
+`
+
+export default React.memo(Volume)

--- a/components/market/search/Input.tsx
+++ b/components/market/search/Input.tsx
@@ -1,0 +1,66 @@
+import React, { useState } from 'react'
+import styled from 'styled-components'
+import SearchIcon from '@mui/icons-material/Search'
+import { useObservable, useSubscription } from 'observable-hooks'
+import { debounceTime, distinctUntilChanged, map } from 'rxjs'
+import { useAppDispatch, useAppSelector } from '@features/hooks'
+import { searchSymbol as testSearchSymbol } from '@features/market/marketSlice'
+
+function Input() {
+ const dispatch = useAppDispatch()
+ const result = useAppSelector((state) => state.market.searchSymbol)
+ const [searchSymbol, setSearchSymbol] = useState<string>('')
+ const value$ = useObservable(
+  (inputs$) =>
+   inputs$.pipe(
+    map(([value]) => value),
+    debounceTime(150),
+    distinctUntilChanged(),
+   ),
+  [searchSymbol],
+ )
+
+ const handleSearchSybol = (searchSymbol: string) => {
+  dispatch(testSearchSymbol(searchSymbol))
+ }
+
+ useSubscription(value$, handleSearchSybol)
+
+ return (
+  <InputBlock>
+   <input
+    placeholder="코인명/심볼검색"
+    type="text"
+    name="symbol"
+    onChange={(e) => setSearchSymbol(e.target.value)}
+    value={searchSymbol}
+   />
+   <div>
+    <SearchIcon color="primary" />
+    {result}
+   </div>
+  </InputBlock>
+ )
+}
+
+export default Input
+
+const InputBlock = styled.div`
+ display: flex;
+ align-items: center;
+
+ input {
+  flex: 1;
+  border: none;
+  outline: none;
+  padding: 0.765rem;
+  font-size: 1.125rem;
+  font-weight: bold;
+  border: 1px solid white;
+  border-bottom: 1px solid #d4d4d4;
+
+  &:focus {
+   border: 1px solid #448fff;
+  }
+ }
+`

--- a/containers/market/grid/GridContainer.tsx
+++ b/containers/market/grid/GridContainer.tsx
@@ -1,0 +1,30 @@
+import Grid from '@components/market/grid/Grid'
+import { useAppSelector } from '@features/hooks'
+import { useMarkets } from '@hooks/query/useMarkets'
+import React, { useRef } from 'react'
+import * as _ from 'lodash'
+
+interface Props {
+ symbols: string
+}
+
+function GridContainer(props: Props) {
+ const { symbols } = props
+ const searchSymbol = useAppSelector((state) => state.market.searchSymbol)
+ const ref = useRef<HTMLDivElement>(null)
+
+ const { data } = useMarkets(symbols, {
+  suspense: true,
+  refetchInterval: 20000,
+ })
+
+ const result = _.filter(data, (test) => {
+  const reg = new RegExp(searchSymbol, 'ig')
+
+  return reg.test(test.market)
+ })
+
+ return <div ref={ref}>{data && <Grid data={result} />}</div>
+}
+
+export default GridContainer

--- a/features/market/marketSlice.ts
+++ b/features/market/marketSlice.ts
@@ -1,0 +1,30 @@
+import { createSlice } from '@reduxjs/toolkit'
+import type { PayloadAction } from '@reduxjs/toolkit'
+import type { Market } from '@interface/market'
+
+interface MarketSlice {
+ markets: Market[]
+ searchSymbol: string
+}
+
+const initialState: MarketSlice = {
+ markets: [],
+ searchSymbol: '',
+}
+
+export const marketSlice = createSlice({
+ name: 'market',
+ initialState,
+ reducers: {
+  invoke: (state, action: PayloadAction<Market[]>) => {
+   state.markets = action.payload
+  },
+  searchSymbol: (state, action: PayloadAction<string>) => {
+   state.searchSymbol = action.payload
+  },
+ },
+})
+
+export const { invoke, searchSymbol } = marketSlice.actions
+
+export default marketSlice.reducer

--- a/hooks/query/useMarkets.ts
+++ b/hooks/query/useMarkets.ts
@@ -1,0 +1,11 @@
+import type { UseQueryOptionsOf } from '@interface/index'
+import { useQuery } from '@tanstack/react-query'
+import { getMarkets } from 'libs/api/markets'
+
+export function useMarkets(symbols: string, options: UseQueryOptionsOf<typeof getMarkets> = {}) {
+ return useQuery(extractKey(symbols), () => getMarkets(symbols), options)
+}
+
+const extractKey = (symbols: string) => ['markets', symbols]
+
+useMarkets.extractKey = extractKey

--- a/libs/api/markets.ts
+++ b/libs/api/markets.ts
@@ -1,0 +1,7 @@
+import axios from 'axios'
+import type { CandleByTickerProps } from '@interface/market'
+
+export async function getMarkets(symbols: string) {
+ const { data } = await axios.get<CandleByTickerProps[]>(`https://api.upbit.com/v1/ticker?markets=${symbols}`)
+ return data
+}

--- a/pages/balances/index.tsx
+++ b/pages/balances/index.tsx
@@ -1,0 +1,89 @@
+import { useAppSelector } from '@features/hooks'
+import useAsync from 'hooks/useAxios'
+import React from 'react'
+
+export interface Geo {
+ lat: string
+ lng: string
+}
+
+export interface Address {
+ street: string
+ suite: string
+ city: string
+ zipcode: string
+ geo: Geo
+}
+
+export interface Company {
+ name: string
+ catchPhrase: string
+ bs: string
+}
+
+export interface RootObject {
+ id: number
+ name: string
+ username: string
+ email: string
+ address: Address
+ phone: string
+ website: string
+ company: Company
+}
+
+function Balances() {
+ const count = useAppSelector((state) => state.counter.value)
+ const { state, fetchData, cancel } = useAsync<RootObject>(
+  {
+   url: 'https://jsonplaceholder.typicode.com/users/5',
+   method: 'GET',
+  },
+  [],
+  true,
+ )
+ const { state: state2, fetchData: fetchData2 } = useAsync<RootObject>(
+  {
+   url: 'https://jsonplaceholder.typicode.com/users/5',
+   method: 'GET',
+  },
+  [],
+  false,
+ )
+ const { loading, data: users, error } = state
+ const { loading: loading2, data: users2, error: error2 } = state2
+ console.log(loading, loading2)
+ if (loading || loading2)
+  return (
+   <div>
+    로딩중..<button onClick={cancel}>cancel</button>
+   </div>
+  )
+
+ console.log(error2?.code, error2)
+ if (error || error2)
+  return (
+   <div>
+    에러가 발생했습니다<button onClick={fetchData}>불러오기</button>
+    <button onClick={fetchData2}>불러오기2</button>
+   </div>
+  )
+ if (!users && !users2)
+  return (
+   <>
+    <button onClick={fetchData}>불러오기</button>
+    <button onClick={fetchData2}>불러오기2</button>
+   </>
+  )
+
+ return (
+  <div>
+   Balances {count} {users?.id} {users2?.id}
+   <button onClick={cancel}>cancel</button>
+   <button onClick={fetchData}>불러오기</button>
+   <button onClick={fetchData2}>불러오기2</button>
+  </div>
+ )
+}
+
+export default Balances

--- a/pages/exchange/index.tsx
+++ b/pages/exchange/index.tsx
@@ -1,0 +1,79 @@
+import { gql, useQuery } from '@apollo/client'
+import Input from '@components/market/search/Input'
+import { increment } from '@features/counter/counterSlice'
+import { useAppDispatch, useAppSelector } from '@features/hooks'
+import { invoke } from '@features/market/marketSlice'
+import { wrapper } from '@features/store'
+import type { Market } from '@interface/market'
+import { dehydrate, QueryClient } from '@tanstack/react-query'
+import axios from 'axios'
+import GridContainer from 'containers/market/grid/GridContainer'
+import { Post, QueryPostArgs } from 'generated/graphql'
+import { getMarkets } from 'libs/api/markets'
+import type { GetServerSideProps, NextPage } from 'next'
+import { Suspense } from 'react'
+
+const GET_ORDER = gql`
+ query post($id: ID!) {
+  post(id: $id) {
+   body
+   id
+   title
+   user {
+    name
+   }
+  }
+ }
+`
+
+const Exchange: NextPage<{ symbolSnake: string }> = (props) => {
+ const { symbolSnake } = props
+ const count = useAppSelector((state) => state.counter.value)
+ const dispatch = useAppDispatch()
+
+ useQuery<Post, QueryPostArgs>(GET_ORDER, {
+  variables: {
+   id: '5',
+  },
+ })
+
+ return (
+  <div>
+   <Input />
+   <Suspense fallback={<div>lㅋㅋㅋㅋㅋㅋㅋㅋoading</div>}>
+    <GridContainer symbols={symbolSnake} />
+   </Suspense>
+   <button type="button" onClick={() => dispatch(increment())}>
+    dispatch
+   </button>
+   main page count {count}
+  </div>
+ )
+}
+
+export const getServerSideProps: GetServerSideProps = wrapper.getServerSideProps((store) => async (context) => {
+ const symbol = context.query.symbol
+ const markets = await axios.get<Market[]>('https://api.upbit.com/v1/market/all').then((res) => res.data)
+ const krwMarkets = markets.filter((market) => market.market.startsWith('KRW-'))
+ await store.dispatch(invoke(krwMarkets))
+
+ const symbolSnake = krwMarkets.map((market) => market.market).join(',')
+
+ const queryClient = new QueryClient()
+ await queryClient.prefetchQuery(['markets', symbolSnake], () => getMarkets(symbolSnake))
+
+ return {
+  ...(!symbol && {
+   redirect: {
+    permanent: false,
+    destination: '/exchange?symbol=KRW-BTC',
+   },
+  }),
+  props: {
+   dehydratedState: dehydrate(queryClient),
+   symbolSnake,
+  },
+ }
+})
+
+export default Exchange

--- a/types/index.ts
+++ b/types/index.ts
@@ -1,0 +1,9 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { UseQueryOptions } from '@tanstack/react-query'
+
+export type UseQueryOptionsOf<T extends (...args: any) => any> = UseQueryOptions<
+ Awaited<ReturnType<T>>,
+ unknown,
+ Awaited<ReturnType<T>>,
+ any[]
+>

--- a/types/market/index.ts
+++ b/types/market/index.ts
@@ -1,0 +1,36 @@
+export type Market = {
+ market: string
+ korean_name: string
+ english_name: string
+}
+
+export type Change = 'RISE' | 'EVEN' | 'FALL'
+
+export interface CandleByTickerProps {
+ market: string
+ trade_date: string
+ trade_time: string
+ trade_date_kst: string
+ trade_time_kst: string
+ trade_timestamp: number
+ opening_price: number
+ high_price: number
+ low_price: number
+ trade_price: number
+ prev_closing_price: number
+ change: Change
+ change_price: number
+ change_rate: number
+ signed_change_price: number
+ signed_change_rate: number
+ trade_volume: number
+ acc_trade_price: number
+ acc_trade_price_24h: number
+ acc_trade_volume: number
+ acc_trade_volume_24h: number
+ highest_52_week_price: number
+ highest_52_week_date: string
+ lowest_52_week_price: number
+ lowest_52_week_date: string
+ timestamp: string
+}

--- a/utils/markets/index.ts
+++ b/utils/markets/index.ts
@@ -1,0 +1,27 @@
+export function numberToHuman(volume: number | string) {
+ const num = +volume
+ const unitWords = ['', '백만']
+ const splitUnit = 1000000
+ const splitCount = unitWords.length
+
+ const resultArray: number[] = []
+ let resultString: string[] = []
+
+ for (let i = 0; i < splitCount; i += 1) {
+  const unitRound = splitUnit ** (i + 1)
+  const splitPhase = splitUnit ** i
+  const unitResult = Math.floor((num % unitRound) / splitPhase)
+
+  if (unitResult > 0) {
+   resultArray[i] = unitResult
+  }
+
+  for (let i = 0, len = resultArray.length; i < len; i += 1) {
+   if (resultArray[i]) {
+    resultString = [String(resultArray[i].toLocaleString()), unitWords[i]]
+   }
+  }
+ }
+
+ return resultString
+}


### PR DESCRIPTION
redux toolkit, react-query, rxjs and d3.js

업비트 API를 이용하여 업비트 원화마켓 거래소 구현

- 거래소 page
- 원화마켓 리스트 컴포넌트
- 원화마켓 검색(rxjs)
- 원화마켓 당일 시세 캔들 구현(d3.js)